### PR TITLE
Fix the address handling for editing existing address #952

### DIFF
--- a/party.py
+++ b/party.py
@@ -169,17 +169,17 @@ class Address(ModelSQL, ModelView):
             return redirect(url_for('party.address.view_address'))
         elif request.method == 'GET' and address:
             # Its an edit of existing address, prefill data
-            record = cls(address)
+            address = cls(address)
             form = AddressForm(
-                name=record.name,
-                street=record.street,
-                streetbis=record.streetbis,
-                zip=record.zip,
-                city=record.city,
-                country=record.country.id,
-                subdivision=record.subdivision.id,
-                email=record.email,
-                phone=record.phone
+                name=address.name,
+                street=address.street,
+                streetbis=address.streetbis,
+                zip=address.zip,
+                city=address.city,
+                country=address.country and address.country.id,
+                subdivision=address.subdivision and address.subdivision.id,
+                email=address.email,
+                phone=address.phone
             )
             form.country.choices = countries
         return render_template('address-edit.jinja', form=form, address=address)

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -125,7 +125,9 @@ class TestAddress(NereidTestCase):
             'localhost/reset-password.jinja': '',
             'localhost/change-password.jinja':
                     '{{ change_password_form.errors }}',
-            'localhost/address-edit.jinja': 'Address Edit {{ form.errors }}',
+            'localhost/address-edit.jinja':
+                'Address Edit {% if address %}ID:{{ address.id }}{% endif %}'
+                '{{ form.errors }}',
             'localhost/address.jinja': '',
             'localhost/account.jinja': '',
             'localhost/emails/activation-text.jinja': 'activation-email-text',
@@ -235,6 +237,11 @@ class TestAddress(NereidTestCase):
                 # automatically with the party
                 self.assertEqual(len(registered_user.party.addresses), 1)
                 existing_address, = registered_user.party.addresses
+
+                response = c.get(
+                    '/en_US/edit-address/%d' % existing_address.id
+                )
+                self.assertTrue('ID:%s' % existing_address.id in response.data)
 
                 # POST to the existing address must updatethe existing address
                 response = c.post(


### PR DESCRIPTION
This patch makes sure that the address parameter passed to the template is an
active record.
It also handles the case where country and subdivision are not present in the
address and prevent blowup due to same.
Tests for the above.
